### PR TITLE
Add multi sha support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ python3 appdome_api.py \
 --firebase_app_id <app-id for uploading mapping file for crashlytics (requires --deobfuscation_script_output and firebase CLI tools)>
 --datadog_api_key <datadog api key for uploading mapping file to datadog (requires --deobfuscation_script_output)>
 --baseline_profile <zip file for build with baseline profile>
+--cert_pinning_zip <zip file containing dynamic certificates>
+--signing_fingerprint_list <path_to_json_file> \
 --new_bundle_id <new bundle id>
 --new_version <new app version>
 --new_build_num <new app build number>
@@ -73,6 +75,7 @@ python3 appdome_api.py \
 --entitlements <entitlements file> <another entitlements file if needed> \
 --output <output ipa> \
 --certificate_output <output certificate pdf>
+--cert_pinning_zip <zip file containing dynamic certificates>
 --new_bundle_id <new bundle id>
 --new_version <new app version>
 --new_build_num <new app build number>
@@ -92,6 +95,45 @@ python3 appdome_api_sdk.py \
 --output <output zip> \
 --certificate_output <output certificate pdf>
 ```
+
+## Signing Fingerprint List
+
+The `--signing_fingerprint_list` (or `-sfp`) option allows you to specify a list of trusted signing fingerprints for Android signing. This is useful when you need to support multiple signing certificates.
+
+**Usage:**
+```bash
+--signing_fingerprint_list <path_to_json_file>
+```
+
+**JSON File Format:**
+The JSON file should contain an array of fingerprint objects. Each object must include:
+- `SHA`: The SHA-1 or SHA-256 certificate fingerprint (required)
+
+**Example JSON file (`fingerprints.json`):**
+```json
+[
+  {
+    "SHA": "E71186B4D94016F0A3F2A68DF5BC75D27CA307663C6DFDE5923084486D43150E",
+    "TrustedStoreSigning": false
+  },
+  {
+    "SHA": "857444B499AAABF7DF388DEA89CC2DA0258273B7C1B091866FA1267E8AA3495D",
+    "TrustedStoreSigning": true
+  },
+  {
+    "SHA": "C11E39F29C946A6408E5C5EA65D94FCB05C0DB302B43E6A8ABCB01256257442A",
+    "TrustedStoreSigning": true
+  }
+]
+```
+
+**Important Notes:**
+- The `--signing_fingerprint_list` option cannot be used together with:
+  - `--signing_fingerprint` (`-cf`)
+  - `--signing_fingerprint_upgrade` (`-cfu`)
+  - `--google_play_signing` (`-gp`)
+- This option is available for Android signing operations.
+
 
 # Update Certificate Pinning
 To update certificate pinning, you need to bundle your certificates and mapping file into a ZIP archive and pass it to your build command.

--- a/appdome-api-python/README.md
+++ b/appdome-api-python/README.md
@@ -102,6 +102,17 @@ python3 sign.py --task_id <task id value>
 --sign_overrides <overrides json file>
 ```
 
+**Android (with signing fingerprint list)**
+```
+python3 sign.py --task_id <task id value>
+--keystore <keystore file>
+--keystore_pass <keystore password>
+--keystore_alias <key alias>
+--key_pass <key password>
+--signing_fingerprint_list <path_to_json_file>
+--sign_overrides <overrides json file>
+```
+
 **iOS**
 
 ```
@@ -125,6 +136,13 @@ python3 private_sign.py --task_id <task id value>
 --google_play_signing
 ```
 
+**Android (with signing fingerprint list)**
+```
+python3 private_sign.py --task_id <task id value>
+--signing_fingerprint_list <path_to_json_file>
+--sign_overrides <overrides json file>
+```
+
 **iOS**
 
 ```
@@ -143,6 +161,12 @@ python3 private_sign.py --task_id <task id value>
 python3 auto_dev_sign.py --task_id <task id value>
 --signing_fingerprint <signing fingerprint>
 --google_play_signing
+```
+
+**Android (with signing fingerprint list)**
+```
+python3 auto_dev_sign.py --task_id <task id value>
+--signing_fingerprint_list <path_to_json_file>
 ```
 
 **iOS**

--- a/appdome-api-python/appdome_api.py
+++ b/appdome-api-python/appdome_api.py
@@ -3,6 +3,7 @@ import logging
 from enum import Enum
 from os import getenv
 from os.path import splitext
+
 from build_to_test import BuildToTestVendors, build_to_test, init_automation_vendor
 from auto_dev_sign import auto_dev_sign_android, auto_dev_sign_ios
 from build import build
@@ -16,7 +17,9 @@ from sign import sign_android, sign_ios
 from status import wait_for_status_complete
 from upload import upload
 from utils import (validate_response, log_and_exit, add_common_args, init_common_args, validate_output_path,
-                   init_overrides, init_baseline_file, init_certs_pinning)
+                   init_overrides, init_baseline_file, init_certs_pinning, add_signing_credentials_args, TASK_ID_KEY,
+                   android_keystore, android_keystore_pass, android_keystore_alias, android_key_pass, ios_p12, ios_p12_password,
+                   ios_provisioning_profiles, validate_trusted_fingerprint_list_args)
 from status import _get_obfuscation_map_status
 from upload_mapping_file import upload_mapping_file
 
@@ -61,26 +64,7 @@ def parse_arguments():
     sign_group.add_argument('-adps', '--auto_dev_private_signing', action='store_true',
                             help='Use a pre-generated signing script for automated local signing')
 
-    # Signing credentials
-    parser.add_argument('-k', '--keystore', metavar='keystore_file',
-                        help='Path to keystore file to use on Appdome iOS and Android signing.')
-    parser.add_argument('-kp', '--keystore_pass', metavar='keystore_password',
-                        help='Password for keystore to use on Appdome iOS and Android signing..')
-    parser.add_argument('-ka', '--keystore_alias', metavar='key_alias',
-                        help='Key alias to use on Appdome Android signing.')
-    parser.add_argument('-kyp', '--key_pass', metavar='key_password',
-                        help='Password for the key to use on Appdome Android signing.')
-    parser.add_argument('-cf', '--signing_fingerprint', metavar='signing_fingerprint',
-                        help='SHA-1 or SHA-256 final Android signing certificate fingerprint.')
-    parser.add_argument('-cfu', '--signing_fingerprint_upgrade', metavar='signing_fingerprint_upgrade',
-                        help='SHA-1 or SHA-256 Upgraded signing certificate fingerprint for Google Play App Signing.')
-    parser.add_argument('-gp', '--google_play_signing', action='store_true',
-                        help='This Android application will be distributed via the Google Play App Signing program.')
-    parser.add_argument('-pr', '--provisioning_profiles', nargs='+', metavar='provisioning_profile_file',
-                        help='Path to iOS provisioning profiles files to use. Can be multiple profiles')
-    parser.add_argument('-entt', '--entitlements', nargs='+', metavar='entitlements_plist_path',
-                        help='Path to iOS entitlements plist to use. Can be multiple entitlements files')
-
+    add_signing_credentials_args(parser)
     # Output parameters
     parser.add_argument('-o', '--output', metavar='output_app_file',
                         help='Output file for fused and signed app after Appdome')
@@ -126,23 +110,27 @@ def validate_args(args):
             log_and_exit(f"fusion_set_id must be specified or set though the correct platform environment variable")
 
     if args.private_signing or args.auto_dev_private_signing:
-        if platform == Platform.ANDROID and not args.signing_fingerprint:
-            log_and_exit(f"signing_fingerprint must be specified when using any Android local signing")
+        if platform == Platform.ANDROID and not args.signing_fingerprint and not args.signing_fingerprint_list:
+            log_and_exit(f"signing_fingerprint or signing_fingerprint_list must be specified when using any Android local signing")
 
-    if platform == Platform.IOS and not args.provisioning_profiles:
+    if platform == Platform.IOS and not ios_provisioning_profiles(args):
         log_and_exit(f"provisioning_profiles must be specified when using any iOS signing")
 
     if args.sign_on_appdome:
-        if not args.keystore or not args.keystore_pass:
-            log_and_exit(f"keystore and keystore_pass must be specified when using on Appdome signing")
-        if platform == Platform.ANDROID and (not args.keystore_alias or not args.key_pass):
-            log_and_exit(f"keystore_alias and key_pass must be specified when using on Appdome Android signing")
+        if platform == Platform.IOS:
+            if not all([ios_p12(args), ios_p12_password(args)]):
+                log_and_exit(f"All ios signing credentials(keystore, keystore_pass) must be specified when using on Appdome signing")
+        if platform == Platform.ANDROID:
+            if not all([android_keystore(args), android_keystore_pass(args), android_keystore_alias(args), android_key_pass(args)]):
+                log_and_exit(f"All android signing credentials(keystore, keystore_pass, keystore_alias, key_pass) must be specified when using on Appdome signing")
         if args.google_play_signing and not args.signing_fingerprint:
             log_and_exit(f"Google signing fingerprint requires providing a signing fingerprint")
 
     if args.build_to_test_vendor and not any(
             args.build_to_test_vendor == vendor.value for vendor in BuildToTestVendors):
         log_and_exit(f"Vendor name provided for Build To Test isn't one of the acceptable vendors")
+
+    validate_trusted_fingerprint_list_args(args)
 
     if args.google_play_signing:
         if args.signing_fingerprint_upgrade and not args.signing_fingerprint:
@@ -156,7 +144,7 @@ def validate_args(args):
 
 def _upload(api_key, team_id, app_path, direct_upload_param=False):
     upload_func = direct_upload if direct_upload_param else upload
-    upload_response = upload(api_key, team_id, app_path)
+    upload_response = upload_func(api_key, team_id, app_path)
     validate_response(upload_response)
     logging.info(f"Upload done. App-id: {upload_response.json()['id']}")
     return upload_response.json()['id']
@@ -177,7 +165,7 @@ def _build(api_key, team_id, app_id, fusion_set_id, build_overrides, use_diagnos
                                files=files)
     validate_response(build_response)
     logging.info(f"Build request started. Response: {build_response.json()}")
-    task_id = build_response.json()['task_id']
+    task_id = build_response.json()[TASK_ID_KEY]
     wait_for_status_complete(api_key, team_id, task_id, operation="build",
                              workflow_output_logs_path=workflow_output_logs)
     logging.info(f"Build request finished.")
@@ -198,24 +186,27 @@ def _sign(args, platform, task_id, sign_overrides, workflow_output_logs=None):
     sign_overrides_json = init_overrides(sign_overrides)
     if platform == Platform.ANDROID:
         if args.sign_on_appdome:
-            r = sign_android(args.api_key, args.team_id, task_id, args.keystore, args.keystore_pass,
-                             args.keystore_alias, args.key_pass,
+            r = sign_android(args.api_key, args.team_id, task_id, android_keystore(args), android_keystore_pass(args),
+                             android_keystore_alias(args), android_key_pass(args),
                              args.signing_fingerprint if args.google_play_signing else None, sign_overrides_json,
-                             args.signing_fingerprint_upgrade if args.google_play_signing else None)
+                             args.signing_fingerprint_upgrade if args.google_play_signing else None,
+                             args.signing_fingerprint_list)
         elif args.private_signing:
             r = private_sign_android(args.api_key, args.team_id, task_id, args.signing_fingerprint,
-                                     args.google_play_signing, sign_overrides_json, args.signing_fingerprint_upgrade)
+                                     args.google_play_signing, sign_overrides_json, args.signing_fingerprint_upgrade,
+                                     args.signing_fingerprint_list)
         else:
             r = auto_dev_sign_android(args.api_key, args.team_id, task_id, args.signing_fingerprint,
-                                      args.google_play_signing, sign_overrides_json, args.signing_fingerprint_upgrade)
+                                      args.google_play_signing, sign_overrides_json, args.signing_fingerprint_upgrade,
+                                      args.signing_fingerprint_list)
     else:
         if args.sign_on_appdome:
-            r = sign_ios(args.api_key, args.team_id, task_id, args.keystore, args.keystore_pass,
-                         args.provisioning_profiles, args.entitlements, sign_overrides_json)
+            r = sign_ios(args.api_key, args.team_id, task_id, ios_p12(args), ios_p12_password(args),
+                         ios_provisioning_profiles(args), args.entitlements, sign_overrides_json)
         elif args.private_signing:
-            r = private_sign_ios(args.api_key, args.team_id, task_id, args.provisioning_profiles, sign_overrides_json)
+            r = private_sign_ios(args.api_key, args.team_id, task_id, ios_provisioning_profiles(args), sign_overrides_json)
         else:
-            r = auto_dev_sign_ios(args.api_key, args.team_id, task_id, args.provisioning_profiles, args.entitlements,
+            r = auto_dev_sign_ios(args.api_key, args.team_id, task_id, ios_provisioning_profiles(args), args.entitlements,
                                   sign_overrides_json)
 
     validate_response(r)

--- a/appdome-api-python/appdome_api.py
+++ b/appdome-api-python/appdome_api.py
@@ -37,6 +37,7 @@ def parse_arguments():
     upload_group.add_argument('--app_id', metavar='app_id_value', help='App id of previously uploaded app')
 
     add_common_args(parser)
+
     parser.add_argument('--direct_upload', action='store_true', help="Upload app directly to Appdome, and not through aws pre-signed url")
     parser.add_argument('-fs', '--fusion_set_id', metavar='fusion_set_id_value',
                         help='Appdome Fusion Set id. '
@@ -46,8 +47,6 @@ def parse_arguments():
                         help='Path to json file with build overrides')
     parser.add_argument('-bl', '--diagnostic_logs', action='store_true',
                         help="Build the app with Appdome's Diagnostic Logs (if licensed)")
-    parser.add_argument('-sv', '--sign_overrides', metavar='overrides_json_file',
-                        help='Path to json file with sign overrides')
     parser.add_argument('-faid', '--firebase_app_id', metavar='firebase_app_id',
                         help='App ID in Firebase project (required for Crashlytics)')
     parser.add_argument('-dd_api_key', '--datadog_api_key', metavar='datadog_api_key',
@@ -58,6 +57,7 @@ def parse_arguments():
                         help='Path to zip file containing dynamic certificates for certificate pinning')
 
     add_context_args(parser)
+
     sign_group = parser.add_mutually_exclusive_group(required=True)
     sign_group.add_argument('-s', '--sign_on_appdome', action='store_true', help='Sign on Appdome')
     sign_group.add_argument('-ps', '--private_signing', action='store_true', help='Sign application manually')

--- a/appdome-api-python/auto_dev_sign.py
+++ b/appdome-api-python/auto_dev_sign.py
@@ -2,15 +2,18 @@ import argparse
 import logging
 
 from utils import (cleaned_fd_list, add_provisioning_profiles_entitlements, run_task_action, add_google_play_signing_fingerprint,
-                   ANDROID_SIGNING_FINGERPRINT_KEY, validate_response, add_common_args, init_common_args, init_overrides)
+                   ANDROID_SIGNING_FINGERPRINT_KEY, validate_response, add_common_args, init_common_args, init_overrides, add_private_signing_args, TASK_ID_KEY,
+                   add_trusted_signing_fingerprint_list, validate_trusted_fingerprint_list_args)
 
 AUTO_DEV_SIGN_ACTION = 'sign_script'
 
 
-def auto_dev_sign_android(api_key, team_id, task_id, signing_fingerprint, is_google_play_signing=False,
-                          sign_overrides=None, signing_fingerprint_upgrade=None):
+def auto_dev_sign_android(api_key, team_id, task_id, signing_fingerprint=None, is_google_play_signing=False,
+                          sign_overrides=None, signing_fingerprint_upgrade=None, trusted_signing_fingerprint_list=None):
     overrides = {}
-    if is_google_play_signing:
+    if trusted_signing_fingerprint_list:
+        add_trusted_signing_fingerprint_list(trusted_signing_fingerprint_list, overrides)
+    elif is_google_play_signing:
         add_google_play_signing_fingerprint(signing_fingerprint, overrides, signing_fingerprint_upgrade)
     else:
         overrides[ANDROID_SIGNING_FINGERPRINT_KEY] = signing_fingerprint
@@ -34,29 +37,25 @@ def auto_dev_sign_ios(api_key, team_id, task_id, provisioning_profiles_paths, en
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Initialize Auto-DEV private signing on Appdome')
     add_common_args(parser, add_task_id=True)
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-pr', '--provisioning_profiles', nargs='+', metavar='provisioning_profile_file', help='Path to iOS provisioning profiles files to use. Can be multiple profiles')
-    group.add_argument('-cf', '--signing_fingerprint', metavar='signing_fingerprint', help='SHA-1 or SHA-256 final Android signing certificate fingerprint.')
-    parser.add_argument('-cfu', '--google_play_signing_fingerprint_upgrade', metavar='signing_fingerprint_upgrade', help='SHA-1 or SHA-256 Google Play upgrade App Signing certificate fingerprint.')
-    parser.add_argument('-entt', '--entitlements', nargs='+', metavar='entitlements_plist_path', help='Path to iOS entitlements plist to use. Can be multiple entitlements files')
-    parser.add_argument('-gp', '--google_play_signing', action='store_true', help='This Android application will be distributed via the Google Play App Signing program.')
-    parser.add_argument('-sv', '--sign_overrides', metavar='overrides_json_file', help='Path to json file with sign overrides')
+    add_private_signing_args(parser, add_entitlements=True)
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     init_common_args(args)
+    validate_trusted_fingerprint_list_args(args)
 
     overrides = init_overrides(args.sign_overrides)
 
-    if args.signing_fingerprint:
-        r = auto_dev_sign_android(args.api_key, args.team_id, args.task_id, args.signing_fingerprint, args.google_play_signing, overrides, args.google_play_signing_fingerprint_upgrade)
+    if args.signing_fingerprint or args.signing_fingerprint_list:
+        r = auto_dev_sign_android(args.api_key, args.team_id, args.task_id, args.signing_fingerprint, args.google_play_signing, overrides,
+                                  args.signing_fingerprint_upgrade, args.signing_fingerprint_list)
     else:
         r = auto_dev_sign_ios(args.api_key, args.team_id, args.task_id, args.provisioning_profiles, args.entitlements, overrides)
 
     validate_response(r)
-    logging.info(f"Auto-DEV private signing for Build id: {r.json()['task_id']} started")
+    logging.info(f"Auto-DEV private signing for Build id: {r.json()[TASK_ID_KEY]} started")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/build.py
+++ b/appdome-api-python/build.py
@@ -5,7 +5,7 @@ import logging
 import requests
 
 from utils import (request_headers, empty_files, validate_response, debug_log_request, TASKS_URL,
-                   ACTION_KEY, OVERRIDES_KEY, add_common_args, init_common_args, init_overrides, team_params)
+                   ACTION_KEY, OVERRIDES_KEY, add_common_args, init_common_args, init_overrides, team_params, TASK_ID_KEY)
 
 
 def create_build_request(api_key, team_id, app_id, fusion_set_id, overrides=None, use_diagnostic_logs=False):
@@ -49,7 +49,7 @@ def main():
 
     r = build(args.api_key, args.team_id, args.app_id, args.fusion_set_id, overrides, args.diagnostic_logs)
     validate_response(r)
-    logging.info(f"Build started: Build id: {r.json()['task_id']}")
+    logging.info(f"Build started: Build id: {r.json()[TASK_ID_KEY]}")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/build_to_test.py
+++ b/appdome-api-python/build_to_test.py
@@ -6,7 +6,7 @@ from enum import Enum
 import requests
 
 from utils import (request_headers, empty_files, validate_response, debug_log_request, BUILD_TO_TEST_URL, log_and_exit,
-                   ACTION_KEY, OVERRIDES_KEY, add_common_args, init_common_args, init_overrides, team_params)
+                   ACTION_KEY, OVERRIDES_KEY, add_common_args, init_common_args, init_overrides, team_params, TASK_ID_KEY)
 
 
 class BuildToTestVendors(Enum):
@@ -88,7 +88,7 @@ def main():
     r = build_to_test(args.api_key, args.team_id, args.app_id, args.fusion_set_id, automation_vendor.name,
                       automation_vendor_err_msg, overrides, args.diagnostic_logs)
     validate_response(r)
-    logging.info(f"Build_to_test started: Build id: {r.json()['task_id']}")
+    logging.info(f"Build_to_test started: Build id: {r.json()[TASK_ID_KEY]}")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/context.py
+++ b/appdome-api-python/context.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from utils import run_task_action, cleaned_fd_list, validate_response, add_common_args, init_common_args
+from utils import run_task_action, cleaned_fd_list, validate_response, add_common_args, init_common_args, TASK_ID_KEY
 
 
 def context(api_key, team_id, task_id, new_bundle_id=None, new_version=None,
@@ -18,7 +18,6 @@ def context(api_key, team_id, task_id, new_bundle_id=None, new_version=None,
         overrides['app_customization_pack_bundle_display_name'] = new_display_name
     if context_overrides:
         overrides.update(context_overrides)
-
     files = {}
     with cleaned_fd_list() as open_fd:
         if app_icon_path:
@@ -39,7 +38,7 @@ def parse_arguments():
     add_common_args(parser, add_task_id=True)
     add_context_args(parser)
     return parser.parse_args()
-            
+
 def add_context_args(parser):
     parser.add_argument('--new_bundle_id', metavar='bundle_id_value', help='Change App identifier')
     parser.add_argument('--new_version', metavar='version_value', help='Change App version')
@@ -56,7 +55,7 @@ def main():
     r = context(args.api_key, args.team_id, args.task_id, args.new_bundle_id, args.new_version, args.new_build_num,
                 args.new_display_name, args.app_icon, args.icon_overlay)
     validate_response(r)
-    logging.info(f"Context for Build id: {r.json()['task_id']} started")
+    logging.info(f"Context for Build id: {r.json()[TASK_ID_KEY]} started")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/private_sign.py
+++ b/appdome-api-python/private_sign.py
@@ -2,15 +2,18 @@ import argparse
 import logging
 
 from utils import (cleaned_fd_list, add_provisioning_profiles_entitlements, run_task_action, add_google_play_signing_fingerprint,
-                   ANDROID_SIGNING_FINGERPRINT_KEY, validate_response, add_common_args, init_common_args, init_overrides)
+                   ANDROID_SIGNING_FINGERPRINT_KEY, validate_response, add_common_args, init_common_args, init_overrides, add_private_signing_args, TASK_ID_KEY,
+                   add_trusted_signing_fingerprint_list, validate_trusted_fingerprint_list_args)
 
 PRIVATE_SIGN_ACTION = 'seal'
 
 
-def private_sign_android(api_key, team_id, task_id, signing_fingerprint, is_google_play_signing=False,
-                         sign_overrides=None, signing_fingerprint_upgrade=None):
+def private_sign_android(api_key, team_id, task_id, signing_fingerprint=None, is_google_play_signing=False,
+                         sign_overrides=None, signing_fingerprint_upgrade=None, trusted_signing_fingerprint_list=None):
     overrides = {}
-    if is_google_play_signing:
+    if trusted_signing_fingerprint_list:
+        add_trusted_signing_fingerprint_list(trusted_signing_fingerprint_list, overrides)
+    elif is_google_play_signing:
         add_google_play_signing_fingerprint(signing_fingerprint, overrides, signing_fingerprint_upgrade)
     else:
         overrides[ANDROID_SIGNING_FINGERPRINT_KEY] = signing_fingerprint
@@ -32,28 +35,25 @@ def private_sign_ios(api_key, team_id, task_id, provisioning_profiles_paths, sig
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Initialize private signing on Appdome')
     add_common_args(parser, add_task_id=True)
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-pr', '--provisioning_profiles', nargs='+', metavar='provisioning_profile_file', help='Path to iOS provisioning profiles files to use. Can be multiple profiles')
-    group.add_argument('-cf', '--signing_fingerprint', metavar='signing_fingerprint', help='SHA-1 or SHA-256 final Android signing certificate fingerprint.')
-    parser.add_argument('-cfu', '--google_play_signing_fingerprint_upgrade', metavar='signing_fingerprint_upgrade', help='SHA-1 or SHA-256 Google Play upgrade App Signing certificate fingerprint.')
-    parser.add_argument('-gp', '--google_play_signing', action='store_true', help='This Android application will be distributed via the Google Play App Signing program.')
-    parser.add_argument('-sv', '--sign_overrides', metavar='overrides_json_file', help='Path to json file with sign overrides')
+    add_private_signing_args(parser)
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     init_common_args(args)
+    validate_trusted_fingerprint_list_args(args)
 
     overrides = init_overrides(args.sign_overrides)
             
-    if args.signing_fingerprint:
-        r = private_sign_android(args.api_key, args.team_id, args.task_id, args.signing_fingerprint, args.google_play_signing, overrides, args.google_play_signing_fingerprint_upgrade)
+    if args.signing_fingerprint or args.signing_fingerprint_list:
+        r = private_sign_android(args.api_key, args.team_id, args.task_id, args.signing_fingerprint, args.google_play_signing, overrides,
+                                 args.signing_fingerprint_upgrade, args.signing_fingerprint_list)
     else:
         r = private_sign_ios(args.api_key, args.team_id, args.task_id, args.provisioning_profiles, overrides)
 
     validate_response(r)
-    logging.info(f"Private signing for Build id: {r.json()['task_id']} started")
+    logging.info(f"Private signing for Build id: {r.json()[TASK_ID_KEY]} started")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/sign.py
+++ b/appdome-api-python/sign.py
@@ -65,7 +65,7 @@ def main():
     if args.keystore_alias:
         r = sign_android(args.api_key, args.team_id, args.task_id, android_keystore(args), android_keystore_pass(args),
                          android_keystore_alias(args), android_key_pass(args), args.signing_fingerprint, overrides,
-                         args.signing_fingerprint_upgrade, args.trusted_signing_fingerprint_list)
+                         args.signing_fingerprint_upgrade, args.signing_fingerprint_list)
     else:
         r = sign_ios(args.api_key, args.team_id, args.task_id, ios_p12(args), ios_p12_password(args),
                      ios_provisioning_profiles(args), args.entitlements, overrides)

--- a/appdome-api-python/sign.py
+++ b/appdome-api-python/sign.py
@@ -2,7 +2,10 @@ import argparse
 import logging
 
 from utils import (add_provisioning_profiles_entitlements, add_google_play_signing_fingerprint,
-                   run_task_action, cleaned_fd_list, validate_response, add_common_args, init_common_args, init_overrides)
+                   run_task_action, cleaned_fd_list, validate_response, add_common_args, init_common_args, init_overrides,
+                   add_signing_credentials_args, TASK_ID_KEY, android_keystore, android_keystore_pass, android_keystore_alias,
+                   android_key_pass, ios_p12, ios_p12_password, ios_provisioning_profiles,
+                   add_trusted_signing_fingerprint_list, validate_trusted_fingerprint_list_args)
 
 SIGN_ACTION = 'sign'
 
@@ -10,15 +13,18 @@ SIGN_ACTION = 'sign'
 def sign_android(api_key, team_id, task_id,
                  keystore_path, keystore_pass, key_alias, key_pass,
                  google_play_signing_fingerprint=None, sign_overrides=None,
-                 google_play_signing_fingerprint_upgrade=None):
+                 google_play_signing_fingerprint_upgrade=None, trusted_signing_fingerprint_list=None):
     overrides = {
         'signing_keystore_password':  keystore_pass,
         'signing_keystore_alias': key_alias,
         'signing_keystore_key_password': key_pass
     }
     
-    add_google_play_signing_fingerprint(google_play_signing_fingerprint, overrides,
-                                        google_play_signing_fingerprint_upgrade)
+    if trusted_signing_fingerprint_list:
+        add_trusted_signing_fingerprint_list(trusted_signing_fingerprint_list, overrides)
+    else:
+        add_google_play_signing_fingerprint(google_play_signing_fingerprint, overrides,
+                                            google_play_signing_fingerprint_upgrade)
 
     if sign_overrides:
         overrides.update(sign_overrides)
@@ -45,37 +51,27 @@ def sign_ios(api_key, team_id, task_id,
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Initialize signing on Appdome')
     add_common_args(parser, add_task_id=True)
-    parser.add_argument('-k', '--keystore', required=True, metavar='keystore_file', help='Path to keystore file to use on Appdome iOS and Android signing.')
-    parser.add_argument('-kp', '--keystore_pass', required=True, metavar='keystore_password', help='Password for keystore to use on Appdome iOS and Android signing..')
-    parser.add_argument('-sv', '--sign_overrides', metavar='overrides_json_file', help='Path to json file with sign overrides')
-
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-pr', '--provisioning_profiles', nargs='+', metavar='provisioning_profile_file', help='Path to iOS provisioning profiles files to use. Can be multiple profiles')
-    group.add_argument('-ka', '--keystore_alias', metavar='key_alias', help='Key alias to use on Appdome Android signing.')
-    parser.add_argument('-kyp', '--key_pass', metavar='key_password', help='Password for the key to use on Appdome Android signing.')
-    parser.add_argument('--google_play_signing_fingerprint', metavar='signing_fingerprint', help='SHA-1 or SHA-256 Google Play App Signing certificate fingerprint.')
-    parser.add_argument('--google_play_signing_fingerprint_upgrade', metavar='signing_fingerprint_upgrade', help='SHA-1 or SHA-256 Google Play upgrade App Signing certificate fingerprint.')
-    parser.add_argument('-gp', '--google_play_signing', action='store_true', help='This Android application will be distributed via the Google Play App Signing program.')
-    parser.add_argument('-entt', '--entitlements', nargs='+', metavar='entitlements_plist_path', help='Path to iOS entitlements plist to use. Can be multiple entitlements files')
+    add_signing_credentials_args(parser, True)
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     init_common_args(args)
+    validate_trusted_fingerprint_list_args(args)
 
     overrides = init_overrides(args.sign_overrides)
 
     if args.keystore_alias:
-        r = sign_android(args.api_key, args.team_id, args.task_id, args.keystore, args.keystore_pass,
-                         args.keystore_alias, args.key_pass, args.google_play_signing_fingerprint, overrides,
-                         args.google_play_signing_fingerprint_upgrade)
+        r = sign_android(args.api_key, args.team_id, args.task_id, android_keystore(args), android_keystore_pass(args),
+                         android_keystore_alias(args), android_key_pass(args), args.signing_fingerprint, overrides,
+                         args.signing_fingerprint_upgrade, args.trusted_signing_fingerprint_list)
     else:
-        r = sign_ios(args.api_key, args.team_id, args.task_id, args.keystore, args.keystore_pass,
-                     args.provisioning_profiles, args.entitlements, overrides)
+        r = sign_ios(args.api_key, args.team_id, args.task_id, ios_p12(args), ios_p12_password(args),
+                     ios_provisioning_profiles(args), args.entitlements, overrides)
 
     validate_response(r)
-    logging.info(f"On Appdome signing for Build id: {r.json()['task_id']} started")
+    logging.info(f"On Appdome signing for Build id: {r.json()[TASK_ID_KEY]} started")
 
 
 if __name__ == '__main__':

--- a/appdome-api-python/utils.py
+++ b/appdome-api-python/utils.py
@@ -125,7 +125,7 @@ def validate_trusted_fingerprint_list_args(args):
         if hasattr(args, 'google_play_signing') and args.google_play_signing:
             conflicting_params.append('--google_play_signing')
         if conflicting_params:
-            log_and_exit(f"--trusted_signing_fingerprint_list cannot be used with: {', '.join(conflicting_params)}")
+            log_and_exit(f"--signing_fingerprint_list cannot be used with: {', '.join(conflicting_params)}")
 
 
 def add_provisioning_profiles_entitlements(provisioning_profiles_paths, entitlements_paths, files_list, overrides,

--- a/appdome-api-python/utils.py
+++ b/appdome-api-python/utils.py
@@ -323,7 +323,7 @@ def add_signing_fingerprint_arg(target):
 
 
 def add_trusted_signing_fingerprint_list_arg(parser):
-    parser.add_argument('-sfp', '--signing_fingerprint_list', metavar='trusted_fingerprint_list_json_file',
+    parser.add_argument('-sfp', '--signing_fingerprint_list', metavar='signing_fingerprint_list_json_file',
                         help='Path to JSON file containing trusted signing fingerprint list. Cannot be used with --signing_fingerprint, --signing_fingerprint_upgrade, or --google_play_signing.')
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for multiple trusted Android signing fingerprints and consolidates signing argument handling.
> 
> - Introduces `--signing_fingerprint_list` across Android signing flows (`sign`, `private_sign`, `auto_dev_sign`, full `appdome_api`) and passes it through to API requests
> - Validates conflicts: fingerprint list cannot be combined with `--signing_fingerprint`, `--signing_fingerprint_upgrade`, or `--google_play_signing`
> - Implements helpers in `utils.py` (`add_trusted_signing_fingerprint_list`, `validate_trusted_fingerprint_list_args`) and refactors signing arg builders and platform/env helpers (Android keystore, iOS p12/provisioning)
> - Standardizes response handling using `TASK_ID_KEY` and minor fixes (direct upload selection, logging/args cleanup)
> - Updates `README.md` and detailed examples with new options, examples (incl. Android SDK), and cert pinning notes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1eabf1e1e58438e0c24d47e4eef0a4919ba686. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->